### PR TITLE
makefile fixes and import rgmii_phy_if.v

### DIFF
--- a/common/vivado.mk
+++ b/common/vivado.mk
@@ -86,7 +86,7 @@ distclean: clean
 	vivado -nojournal -nolog -mode batch -source create_project.tcl
 
 # synthesis run
-%.runs/synth_1/%.dcp: %.xpr $(SYN_FILES_REL) $(INC_FILES_REL) $(XDC_FILES_REL)
+runs/synth_1/%.dcp: %.xpr $(SYN_FILES_REL) $(INC_FILES_REL) $(XDC_FILES_REL)
 	echo "open_project $*.xpr" > run_synth.tcl
 	echo "reset_run synth_1" >> run_synth.tcl
 	echo "launch_runs synth_1" >> run_synth.tcl
@@ -95,7 +95,7 @@ distclean: clean
 	vivado -nojournal -nolog -mode batch -source run_synth.tcl
 
 # implementation run
-%.runs/impl_1/%_routed.dcp: %.runs/synth_1/%.dcp
+runs/impl_1/%_routed.dcp: runs/synth_1/%.dcp
 	echo "open_project $*.xpr" > run_impl.tcl
 	echo "reset_run impl_1" >> run_impl.tcl
 	echo "launch_runs impl_1" >> run_impl.tcl
@@ -104,7 +104,7 @@ distclean: clean
 	vivado -nojournal -nolog -mode batch -source run_impl.tcl
 
 # bit file
-%.bit: %.runs/impl_1/%_routed.dcp
+%.bit: runs/impl_1/%_routed.dcp
 	echo "open_project $*.xpr" > generate_bit.tcl
 	echo "open_run impl_1" >> generate_bit.tcl
 	echo "write_bitstream -force $*.bit" >> generate_bit.tcl

--- a/lib/eth/rtl/rgmii_phy_if.v
+++ b/lib/eth/rtl/rgmii_phy_if.v
@@ -1,0 +1,257 @@
+/*
+
+Copyright (c) 2015-2018 Alex Forencich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// Language: Verilog 2001
+
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+/*
+ * RGMII PHY interface
+ */
+module rgmii_phy_if #
+(
+    // target ("SIM", "GENERIC", "XILINX", "ALTERA")
+    parameter TARGET = "GENERIC",
+    // IODDR style ("IODDR", "IODDR2")
+    // Use IODDR for Virtex-4, Virtex-5, Virtex-6, 7 Series, Ultrascale
+    // Use IODDR2 for Spartan-6
+    parameter IODDR_STYLE = "IODDR2",
+    // Clock input style ("BUFG", "BUFR", "BUFIO", "BUFIO2")
+    // Use BUFR for Virtex-6, 7-series
+    // Use BUFG for Virtex-5, Spartan-6, Ultrascale
+    parameter CLOCK_INPUT_STYLE = "BUFG",
+    // Use 90 degree clock for RGMII transmit ("TRUE", "FALSE")
+    parameter USE_CLK90 = "TRUE"
+)
+(
+    input  wire        clk,
+    input  wire        clk90,
+    input  wire        rst,
+
+    /*
+     * GMII interface to MAC
+     */
+    output wire        mac_gmii_rx_clk,
+    output wire        mac_gmii_rx_rst,
+    output wire [7:0]  mac_gmii_rxd,
+    output wire        mac_gmii_rx_dv,
+    output wire        mac_gmii_rx_er,
+    output wire        mac_gmii_tx_clk,
+    output wire        mac_gmii_tx_rst,
+    output wire        mac_gmii_tx_clk_en,
+    input  wire [7:0]  mac_gmii_txd,
+    input  wire        mac_gmii_tx_en,
+    input  wire        mac_gmii_tx_er,
+
+    /*
+     * RGMII interface to PHY
+     */
+    input  wire        phy_rgmii_rx_clk,
+    input  wire [3:0]  phy_rgmii_rxd,
+    input  wire        phy_rgmii_rx_ctl,
+    output wire        phy_rgmii_tx_clk,
+    output wire [3:0]  phy_rgmii_txd,
+    output wire        phy_rgmii_tx_ctl,
+
+    /*
+     * Control
+     */
+    input  wire [1:0]  speed
+);
+
+// receive
+
+wire rgmii_rx_ctl_1;
+wire rgmii_rx_ctl_2;
+
+ssio_ddr_in #
+(
+    .TARGET(TARGET),
+    .CLOCK_INPUT_STYLE(CLOCK_INPUT_STYLE),
+    .IODDR_STYLE(IODDR_STYLE),
+    .WIDTH(5)
+)
+rx_ssio_ddr_inst (
+    .input_clk(phy_rgmii_rx_clk),
+    .input_d({phy_rgmii_rxd, phy_rgmii_rx_ctl}),
+    .output_clk(mac_gmii_rx_clk),
+    .output_q1({mac_gmii_rxd[3:0], rgmii_rx_ctl_1}),
+    .output_q2({mac_gmii_rxd[7:4], rgmii_rx_ctl_2})
+);
+
+assign mac_gmii_rx_dv = rgmii_rx_ctl_1;
+assign mac_gmii_rx_er = rgmii_rx_ctl_1 ^ rgmii_rx_ctl_2;
+
+// transmit
+
+reg rgmii_tx_clk_1 = 1'b1;
+reg rgmii_tx_clk_2 = 1'b0;
+reg rgmii_tx_clk_en = 1'b1;
+
+reg [5:0] count_reg = 6'd0, count_next;
+
+always @(posedge clk) begin
+    rgmii_tx_clk_1 <= rgmii_tx_clk_2;
+
+    if (speed == 2'b00) begin
+        // 10M
+        count_reg <= count_reg + 1;
+        rgmii_tx_clk_en <= 1'b0;
+        if (count_reg == 24) begin
+            rgmii_tx_clk_1 <= 1'b1;
+            rgmii_tx_clk_2 <= 1'b1;
+        end else if (count_reg >= 49) begin
+            rgmii_tx_clk_2 <= 1'b0;
+            rgmii_tx_clk_en <= 1'b1;
+            count_reg <= 0;
+        end
+    end else if (speed == 2'b01) begin
+        // 100M
+        count_reg <= count_reg + 1;
+        rgmii_tx_clk_en <= 1'b0;
+        if (count_reg == 2) begin
+            rgmii_tx_clk_1 <= 1'b1;
+            rgmii_tx_clk_2 <= 1'b1;
+        end else if (count_reg >= 4) begin
+            rgmii_tx_clk_2 <= 1'b0;
+            rgmii_tx_clk_en <= 1'b1;
+            count_reg <= 0;
+        end
+    end else begin
+        // 1000M
+        rgmii_tx_clk_1 <= 1'b1;
+        rgmii_tx_clk_2 <= 1'b0;
+        rgmii_tx_clk_en <= 1'b1;
+    end
+
+    if (rst) begin
+        rgmii_tx_clk_1 <= 1'b1;
+        rgmii_tx_clk_2 <= 1'b0;
+        rgmii_tx_clk_en <= 1'b1;
+        count_reg <= 0;
+    end
+end
+
+reg [3:0] rgmii_txd_1 = 0;
+reg [3:0] rgmii_txd_2 = 0;
+reg rgmii_tx_ctl_1 = 1'b0;
+reg rgmii_tx_ctl_2 = 1'b0;
+
+reg gmii_clk_en = 1'b1;
+
+always @* begin
+    if (speed == 2'b00) begin
+        // 10M
+        rgmii_txd_1 = mac_gmii_txd[3:0];
+        rgmii_txd_2 = mac_gmii_txd[3:0];
+        if (rgmii_tx_clk_1) begin
+            rgmii_tx_ctl_1 = mac_gmii_tx_en ^ mac_gmii_tx_er;
+            rgmii_tx_ctl_2 = mac_gmii_tx_en ^ mac_gmii_tx_er;
+        end else begin
+            rgmii_tx_ctl_1 = mac_gmii_tx_en;
+            rgmii_tx_ctl_2 = mac_gmii_tx_en;
+        end
+        gmii_clk_en = rgmii_tx_clk_en;
+    end else if (speed == 2'b01) begin
+        // 100M
+        rgmii_txd_1 = mac_gmii_txd[3:0];
+        rgmii_txd_2 = mac_gmii_txd[3:0];
+        if (rgmii_tx_clk_1) begin
+            rgmii_tx_ctl_1 = mac_gmii_tx_en ^ mac_gmii_tx_er;
+            rgmii_tx_ctl_2 = mac_gmii_tx_en ^ mac_gmii_tx_er;
+        end else begin
+            rgmii_tx_ctl_1 = mac_gmii_tx_en;
+            rgmii_tx_ctl_2 = mac_gmii_tx_en;
+        end
+        gmii_clk_en = rgmii_tx_clk_en;
+    end else begin
+        // 1000M
+        rgmii_txd_1 = mac_gmii_txd[3:0];
+        rgmii_txd_2 = mac_gmii_txd[7:4];
+        rgmii_tx_ctl_1 = mac_gmii_tx_en;
+        rgmii_tx_ctl_2 = mac_gmii_tx_en ^ mac_gmii_tx_er;
+        gmii_clk_en = 1;
+    end
+end
+
+wire phy_rgmii_tx_clk_new;
+wire [3:0] phy_rgmii_txd_new;
+wire phy_rgmii_tx_ctl_new;
+
+oddr #(
+    .TARGET(TARGET),
+    .IODDR_STYLE(IODDR_STYLE),
+    .WIDTH(1)
+)
+clk_oddr_inst (
+    .clk(USE_CLK90 == "TRUE" ? clk90 : clk),
+    .d1(rgmii_tx_clk_1),
+    .d2(rgmii_tx_clk_2),
+    .q(phy_rgmii_tx_clk)
+);
+
+oddr #(
+    .TARGET(TARGET),
+    .IODDR_STYLE(IODDR_STYLE),
+    .WIDTH(5)
+)
+data_oddr_inst (
+    .clk(clk),
+    .d1({rgmii_txd_1, rgmii_tx_ctl_1}),
+    .d2({rgmii_txd_2, rgmii_tx_ctl_2}),
+    .q({phy_rgmii_txd, phy_rgmii_tx_ctl})
+);
+
+assign mac_gmii_tx_clk = clk;
+
+assign mac_gmii_tx_clk_en = gmii_clk_en;
+
+// reset sync
+reg [3:0] tx_rst_reg = 4'hf;
+assign mac_gmii_tx_rst = tx_rst_reg[0];
+
+always @(posedge mac_gmii_tx_clk or posedge rst) begin
+    if (rst) begin
+        tx_rst_reg <= 4'hf;
+    end else begin
+        tx_rst_reg <= {1'b0, tx_rst_reg[3:1]};
+    end
+end
+
+reg [3:0] rx_rst_reg = 4'hf;
+assign mac_gmii_rx_rst = rx_rst_reg[0];
+
+always @(posedge mac_gmii_rx_clk or posedge rst) begin
+    if (rst) begin
+        rx_rst_reg <= 4'hf;
+    end else begin
+        rx_rst_reg <= {1'b0, rx_rst_reg[3:1]};
+    end
+end
+
+endmodule
+
+`resetall


### PR DESCRIPTION
 from https://github.com/alexforencich/verilog-ethernet/ we import rgmii_phy_if.v
and a small fix for the common/vivado.mk file to allow the build with more recent versions of ```make```